### PR TITLE
Shopping Cart Feature

### DIFF
--- a/pages/aplicado.html
+++ b/pages/aplicado.html
@@ -122,8 +122,8 @@
                         Total: $<span id="totalAmount">0</span>
                     </div>
                     <div class="modal-footer">
-                        <button id="btnBuy" type="button" class="btn btn-primary" data-bs-dismiss="modal">Continuar Compra</button>
-                        <button id="btnClean" type="button" class="btn btn-danger">Vaciar Carrito</button>
+                        <button id="btnBuy" type="button" class="btn btn-primary" data-bs-dismiss="modal" disabled>Continuar Compra</button>
+                        <button id="btnClean" type="button" class="btn btn-danger" disabled>Vaciar Carrito</button>
                         <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
                     </div>
                 </div>

--- a/static/scripts/products.js
+++ b/static/scripts/products.js
@@ -171,6 +171,8 @@ const addProduct = (id) => {
 
     // If item is already on the shopping cart, increase quantity
     shoppingCart.push(item)
+    btnBuy.disabled = false
+    btnClean.disabled = false
   }
 
   // Update the display of the shopping cart
@@ -236,6 +238,10 @@ const deleteProduct = (id) => {
     shoppingCart.splice(isOnCart, 1)
   }
 
+  // Disable the buy/clear button if the shopping cart is empty
+  shoppingCart.length === 0 ? btnBuy.disabled = true : btnBuy.disabled = false
+  shoppingCart.length === 0 ? btnClean.disabled = true : btnClean.disabled = false
+
   // If the product is not found, return false
   if (isOnCart === -1) return false
 
@@ -285,6 +291,8 @@ btnClean.onclick = () => {
     })
   }
 
+  btnBuy.disabled = true
+  btnClean.disabled = true
   shoppingCart = []
   showShoppingCart()
 }


### PR DESCRIPTION
Adding disabled/enabled methods to avoid client missunderstanding and proceed only to checkout page once we have items in the cart.

If not, the client will not be able to proceed.

As well, I as a clien cant click on "vaciar carrito" if we doesnt have items in the cart. To avoid problems during the event genrator.